### PR TITLE
Change AD scope to solvers only

### DIFF
--- a/examples/convAnalysisRE.m
+++ b/examples/convAnalysisRE.m
@@ -6,7 +6,7 @@
 % Author: Jhabriel Varela. E-mail: Jhabriel.Varela@uib.no. 
 
 %{
-Copyright 2018-2019, University of Bergen.
+Copyright 2018-2020, University of Bergen.
 
 This file is part of the fv-unsat module.
 

--- a/examples/convAnalysisUnsatBiot.m
+++ b/examples/convAnalysisUnsatBiot.m
@@ -6,7 +6,7 @@
 % Author: Jhabriel Varela. E-mail: Jhabriel.Varela@uib.no. 
 
 %{
-Copyright 2018-2019, University of Bergen.
+Copyright 2018-2020, University of Bergen.
 
 This file is part of the fv-unsat module.
 

--- a/utility/computeTopPressure.m
+++ b/utility/computeTopPressure.m
@@ -1,4 +1,4 @@
-function pTop = computeTopPressure(G, p_act, flux, gamma, mu_w, k, krw)
+function pTop = computeTopPressure(G, p, flux, gamma, mu_w, k, krw)
 % Get minimum pressure of the top layer using TPFA
 %
 % SYNOPSIS:
@@ -48,7 +48,7 @@ z_min = find(zf == 0);                  % idx of top faces
 
 % Obtaining minimum value of pTop
 pTop = mean( (((flux(z_min) ./ (A(z_min))) .* zc(1) .* mu_w) ./ ...
-    (mean(krw(p_act.val(1:topCellsNum))) .* k)) - gamma .* ...
+    (mean(krw(p(1:topCellsNum))) .* k)) - gamma .* ...
     (zetaf(z_min) - zetac(1:topCellsNum)) ...
-    + p_act.val(1:topCellsNum));
+    + p(1:topCellsNum));
 end

--- a/utility/solverRE.m
+++ b/utility/solverRE.m
@@ -1,13 +1,12 @@
-function [psi_ad, psi_m, iter] = solverRE(psi_ad, psi_n, psiEq, ...
-    tau, source, currentTime, tol, maxIter)
+function [psi, psi_m, iter] = solverRE(psi_n, psiEq, tau, source, ...
+    currentTime, tol, maxIter)
 % Newton solver for the Richards' equation
 %
 % SYNOPSIS:
-%   function [psi_ad, psi_m, iter] = newtonSolverRE(psi_ad, psi_n, psiEq, ...
-%       tau, source, currentTime)
+%   function [psi, psi_m, iter] = solverRE(psi_n, psiEq, tau, source, ..
+%   currentTime, tol, maxIter)
 %
 % PARAMETERS:
-%   psi_ad       - AD-object, pressure head AD-variable.
 %   psi_n        - Vector, pressure head evaluated at the last time level.
 %   psiEq        - Function, pressure head equation, i.e. mass balance eq.
 %   tau          - Scalar, time step
@@ -17,7 +16,7 @@ function [psi_ad, psi_m, iter] = solverRE(psi_ad, psi_n, psiEq, ...
 %   maxIter      - Scalar, maximum number of iterations
 %
 %  RETURNS:
-%   psi_ad       - AD-object, updated pressure head AD-variable.
+%   psi          - AD-object, updated pressure head AD-variable.
 %   psi_m        - Vector, pressure head evaluated at the last iteration.
 %   iter         - Scalar, number of iterations needed for convergence
 %
@@ -43,7 +42,10 @@ along with this file.  If not, see <http://www.gnu.org/licenses/>.
 
 res = 100;      % residual value
 iter = 1;       % iterations
-    
+
+% Initaliazing AD-variable
+psi_ad = initVariablesADI(psi_n); 
+
 % Newton loop
 while (res > tol) && (iter <= maxIter)
     
@@ -64,5 +66,6 @@ while (res > tol) && (iter <= maxIter)
     else
         iter = iter + 1;
     end
-    
 end
+
+psi = psi_ad.val; % updated pressure head

--- a/utility/solverUnsatBiot.m
+++ b/utility/solverUnsatBiot.m
@@ -1,10 +1,10 @@
-function [p_ad, p_m, u_ad, iter] = solverUnsatBiot(G, p_ad, p_n, ...
-    u_ad, u_n, pEq1, pEq2, uEq1, uEq2, tau, sourceFlow, sourceMech, ...
+function [p, p_m, u, iter] = solverUnsatBiot(G, p_n, u_n, ...
+    pEq1, pEq2, uEq1, uEq2, tau, sourceFlow, sourceMech, ...
     currentTime, tol, maxIter)
 % Newton solver for the equations of unsaturated poroelasticity
 %
 % SYNOPSIS:
-%   function [p_ad, p_m, u_ad, iter] = newtonSolverUnsatBiot(G, p_ad, p_n, ...
+%   function [p, p_m, u_, iter] = solverUnsatBiot(G, p_ad, p_n, ...
 %       u_ad, u_n, pEq1, pEq2, uEq1, uEq2, tau, sourceFlow, sourceMech, ...
 %       currentTime, tol, maxIter)
 %
@@ -55,6 +55,10 @@ iter = 1;           % maximum number of iterations
 Nd = G.griddim;     % grid dimension
 Nc = G.cells.num;   % number of cells
 
+% Initializing AD-variables
+p_ad = initVariablesADI(p_n);
+u_ad = initVariablesADI(u_n);
+
 % Newton loop
 while (res > tol) && (iter <= maxIter)
     
@@ -84,3 +88,6 @@ while (res > tol) && (iter <= maxIter)
     end
     
 end
+
+p = p_ad.val; % updating pressure value
+u = u_ad.val; % updating displacement value


### PR DESCRIPTION
The run scritpts now only deal with non-AD variables. The initialization and manipulation of AD variables is restricted to the solvers.